### PR TITLE
Add docstrings to views and serializers

### DIFF
--- a/categories/serializers.py
+++ b/categories/serializers.py
@@ -1,7 +1,10 @@
 from rest_framework import serializers
 from .models import Category
 
+
 class CategorySerializer(serializers.ModelSerializer):
+    """Serialize category data for API responses and requests."""
+
     class Meta:
         model = Category
         fields = ["id", "name", "description", "created_at", "updated_at"]

--- a/categories/views.py
+++ b/categories/views.py
@@ -4,7 +4,14 @@ from rest_framework import viewsets, permissions
 from .models import Category
 from .serializers import CategorySerializer
 
+
 class CategoryViewSet(viewsets.ModelViewSet):
+    """Manage CRUD operations for product categories.
+
+    Provides list, create, retrieve, update and delete actions. Read-only
+    access is granted to unauthenticated users.
+    """
+
     queryset = Category.objects.all()
     serializer_class = CategorySerializer
     permission_classes = [permissions.IsAuthenticatedOrReadOnly]

--- a/products/serializers.py
+++ b/products/serializers.py
@@ -1,7 +1,14 @@
 from rest_framework import serializers
 from .models import Product
 
+
 class ProductSerializer(serializers.ModelSerializer):
+    """Serialize product instances for API interactions.
+
+    When creating a product, the current authenticated user is set as the
+    creator if provided in the serializer context.
+    """
+
     class Meta:
         model = Product
         fields = [
@@ -11,6 +18,7 @@ class ProductSerializer(serializers.ModelSerializer):
         read_only_fields = ["id", "created_by", "created_date", "updated_date"]
 
     def create(self, validated_data):
+        """Create a product instance and set the creator when available."""
         # auto-attach the logged-in user
         request = self.context.get("request")
         if request and request.user.is_authenticated:

--- a/products/views.py
+++ b/products/views.py
@@ -4,7 +4,15 @@ from django_filters.rest_framework import DjangoFilterBackend
 from .models import Product
 from .serializers import ProductSerializer
 
+
 class ProductViewSet(viewsets.ModelViewSet):
+    """API endpoint for viewing and editing products.
+
+    Provides full CRUD functionality with filtering, searching, and
+    ordering capabilities. Automatically associates the creating user
+    with new products.
+    """
+
     queryset = Product.objects.all().select_related("category", "created_by")
     serializer_class = ProductSerializer
     permission_classes = [permissions.IsAuthenticatedOrReadOnly]
@@ -16,5 +24,6 @@ class ProductViewSet(viewsets.ModelViewSet):
     ordering = ["-created_date"]
 
     def perform_create(self, serializer):
+        """Attach the requesting user as the product creator."""
         serializer.save(created_by=self.request.user)
 

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -2,13 +2,19 @@ from rest_framework import serializers
 from .models import User
 from django.contrib.auth.password_validation import validate_password
 
+
 class UserSerializer(serializers.ModelSerializer):
+    """Serialize public user details for profile operations."""
+
     class Meta:
         model = User
         fields = ["id", "username", "email", "first_name", "last_name", "date_joined"]
         read_only_fields = ["id", "date_joined"]
 
+
 class RegisterSerializer(serializers.ModelSerializer):
+    """Handle user registration with password validation."""
+
     password = serializers.CharField(write_only=True, validators=[validate_password])
 
     class Meta:
@@ -16,6 +22,7 @@ class RegisterSerializer(serializers.ModelSerializer):
         fields = ["username", "email", "password", "first_name", "last_name"]
 
     def create(self, validated_data):
+        """Create a new user from validated registration data."""
         user = User.objects.create_user(
             username=validated_data["username"],
             email=validated_data["email"],

--- a/users/views.py
+++ b/users/views.py
@@ -4,16 +4,27 @@ from rest_framework import generics, permissions
 from .models import User
 from .serializers import UserSerializer, RegisterSerializer
 
+
 class RegisterView(generics.CreateAPIView):
+    """Create a new user account via the API.
+
+    Allows unauthenticated clients to submit registration data and
+    receive a newly created user instance in response.
+    """
+
     queryset = User.objects.all()
     serializer_class = RegisterSerializer
     permission_classes = [permissions.AllowAny]
 
+
 class ProfileView(generics.RetrieveUpdateAPIView):
+    """Retrieve or update the authenticated user's profile."""
+
     queryset = User.objects.all()
     serializer_class = UserSerializer
     permission_classes = [permissions.IsAuthenticated]
 
     def get_object(self):
+        """Return the current authenticated user."""
         return self.request.user
 


### PR DESCRIPTION
## Summary
- document user registration and profile views and serializers
- describe category and product viewsets and serializers

## Testing
- `pip install pydocstyle` (fails: Could not find a version that satisfies the requirement pydocstyle)
- `python - <<'PY'
import os, django
os.environ.setdefault('DJANGO_SETTINGS_MODULE','config.settings')
django.setup()
from categories.views import CategoryViewSet
print('CategoryViewSet docstring:', CategoryViewSet.__doc__)
from products.views import ProductViewSet
print('ProductViewSet docstring:', ProductViewSet.__doc__)
from users.views import RegisterView, ProfileView
print('RegisterView docstring:', RegisterView.__doc__)
print('ProfileView docstring:', ProfileView.__doc__)
PY`
- `python - <<'PY'
import os, django
os.environ.setdefault('DJANGO_SETTINGS_MODULE','config.settings')
django.setup()
from products.serializers import ProductSerializer
print('ProductSerializer docstring:', ProductSerializer.__doc__)
PY`
- `python - <<'PY'
import os, django
os.environ.setdefault('DJANGO_SETTINGS_MODULE','config.settings')
django.setup()
from categories.serializers import CategorySerializer
print('CategorySerializer docstring:', CategorySerializer.__doc__)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b54f73bcb0832690fc8396c92a680e